### PR TITLE
Allow gradle-publish workflow to be manually triggered

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,6 +1,7 @@
 name: Gradle Package
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 


### PR DESCRIPTION
*Description of changes:* Allow gradle-publish workflow to be manually triggered.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
