### PR TITLE
Gha publish

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -42,7 +42,8 @@ jobs:
         echo "signingEnabled=true" > gradle.properties
         echo "mavenUsername=$(aws secretsmanager get-secret-value --region ${{ secrets.AWS_REGION }} --secret-id ${{ secrets.MAVEN_TOKEN_ID }} --query SecretString --output text | jq -r .username)" >> gradle.properties
         echo "mavenPassword=$(aws secretsmanager get-secret-value --region ${{ secrets.AWS_REGION }} --secret-id ${{ secrets.MAVEN_TOKEN_ID }} --query SecretString --output text | jq -r .password)" >> gradle.properties
-        echo "signing.keyId=9FA7DD2A # https://keys.openpgp.org/vks/v1/by-fingerprint/47941890158FC24F3F3DABEAA94D8D549FA7DD2A" >> gradle.properties
+        echo "# Signing key: https://keys.openpgp.org/vks/v1/by-fingerprint/47941890158FC24F3F3DABEAA94D8D549FA7DD2A" >> gradle.properties
+        echo "signing.keyId=9FA7DD2A" >> gradle.properties
         echo "signing.password=$(aws secretsmanager get-secret-value --region ${{ secrets.AWS_REGION }} --secret-id ${{ secrets.GPG_KEY_ID }} --query SecretString --output text | jq -r .passphrase)" >> gradle.properties
         echo "signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg" >> gradle.properties
 


### PR DESCRIPTION
*Description of changes:* Added support to publish s3-tables-catalog to Maven AWS OSS Sonatype, under the namespace `software.amazon.s3tables`. Publishing is automated, and will be executed whenever a new release is created in Github.

Link to succesfull workflow run: https://github.com/awslabs/s3-tables-catalog/actions/runs/12140052000

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
