### PR TITLE
Fix super(shadow) jar build and publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'signing'
     id 'maven-publish'
+    id 'com.gradleup.shadow' version '8.3.5'
 }
 
 group = 'software.amazon.s3tables'
@@ -74,17 +75,50 @@ test {
     useJUnitPlatform()
 }
 
-task superjar(type: Jar) {
-    group = 'super jar'
-    description = 'Creates a self-contained fat JAR of the application that can be run.'
-    manifest {
-        attributes 'Main-Class': 'software.amazon.s3tables.iceberg.S3TablesCatalog'
+shadowJar {
+    // exclude dependencies that are already in Iceberg engine runtimes
+    dependencies {
+        exclude(dependency('com.github.ben-manes.caffeine:caffeine:.*'))
+        exclude(dependency('org.apache.iceberg:.*'))
+        exclude(dependency('com.fasterxml.jackson.core:.*'))
+        exclude(dependency('com.google.errorprone:.*'))
+        exclude(dependency('io.airlift:.*'))
+        exclude(dependency('io.netty:.*'))
+        exclude(dependency('org.apache.avro:.*'))
+        exclude(dependency('org.apache.httpcomponents.client5:.*'))
+        exclude(dependency('org.apache.httpcomponents.core5:.*'))
+        exclude(dependency('org.checkerframework:.*'))
+        exclude(dependency('org.roaringbitmap:.*'))
+        exclude(dependency('org.slf4j:.*'))
     }
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect { zipTree(it) }
-    }
-    with jar
+
+    // relocate project specific dependencies
+    relocate 'software.amazon.awssdk', 'software.amazon.s3tables.shaded.awssdk'
+    relocate 'org.apache.commons', 'software.amazon.s3tables.shaded.org.apache.commons'
+    relocate 'io.netty', 'software.amazon.s3tables.shaded.io.netty'
+    relocate 'org.apache.http', 'software.amazon.s3tables.shaded.org.apache.http'
+
+    // relocate all dependencies that Iceberg engine runtimes already relocates
+    relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
+    relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
+    relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
+    relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
+    relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
+    relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+    relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+    relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+    relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+    relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+    relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+    relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
+    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+    relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
+    relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
+    relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
+
+    archiveClassifier.set("runtime")
 }
 
 publishing {
@@ -117,6 +151,9 @@ publishing {
                     }
                 }
             }
+        }
+        shadow(MavenPublication) {
+            from components.shadow
         }
     }
     repositories {

--- a/src/software/amazon/s3tables/iceberg/S3TablesAwsClientFactories.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesAwsClientFactories.java
@@ -1,10 +1,10 @@
 package software.amazon.s3tables.iceberg;
 
-import org.apache.iceberg.aws.AwsClientProperties;
-import org.apache.iceberg.aws.HttpClientProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.services.s3tables.S3TablesClient;
+import software.amazon.s3tables.iceberg.imports.AwsClientProperties;
+import software.amazon.s3tables.iceberg.imports.HttpClientProperties;
 
 import java.util.Map;
 

--- a/src/software/amazon/s3tables/iceberg/S3TablesCatalogOperations.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesCatalogOperations.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
-import org.apache.iceberg.aws.util.RetryDetector;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -47,6 +46,7 @@ import software.amazon.awssdk.services.s3tables.model.GetTableMetadataLocationRe
 import software.amazon.awssdk.services.s3tables.model.NotFoundException;
 import software.amazon.awssdk.services.s3tables.model.UpdateTableMetadataLocationRequest;
 import software.amazon.awssdk.services.s3tables.model.UpdateTableMetadataLocationResponse;
+import software.amazon.s3tables.iceberg.imports.RetryDetector;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/src/software/amazon/s3tables/iceberg/S3TablesProperties.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesProperties.java
@@ -14,7 +14,7 @@ public class S3TablesProperties implements Serializable {
      * This property is used to pass in the aws client factory implementation class for S3 Tables. The
      * class should implement {@link S3TablesAwsClientFactory}. For example, {@link
      * DefaultS3TablesAwsClientFactory} implements {@link S3TablesAwsClientFactory}. If this property
-     * wasn't set, will load one of {@link org.apache.iceberg.aws.AwsClientFactory} factory classes to
+     * wasn't set, will load one of {@link S3TablesAwsClientFactory} factory classes to
      * provide backward compatibility.
      */
     public static final String CLIENT_FACTORY = "s3tables.client-factory-impl";

--- a/src/software/amazon/s3tables/iceberg/imports/ApacheHttpClientConfigurations.java
+++ b/src/software/amazon/s3tables/iceberg/imports/ApacheHttpClientConfigurations.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package software.amazon.s3tables.iceberg.imports;
+
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache.ProxyConfiguration;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+
+class ApacheHttpClientConfigurations {
+  private Long connectionTimeoutMs;
+  private Long socketTimeoutMs;
+  private Long acquisitionTimeoutMs;
+  private Long connectionMaxIdleTimeMs;
+  private Long connectionTimeToLiveMs;
+  private Boolean expectContinueEnabled;
+  private Integer maxConnections;
+  private Boolean tcpKeepAliveEnabled;
+  private Boolean useIdleConnectionReaperEnabled;
+  private String proxyEndpoint;
+
+  private ApacheHttpClientConfigurations() {}
+
+  public <T extends AwsSyncClientBuilder> void configureHttpClientBuilder(T awsClientBuilder) {
+    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
+    configureApacheHttpClientBuilder(apacheHttpClientBuilder);
+    awsClientBuilder.httpClientBuilder(apacheHttpClientBuilder);
+  }
+
+  private void initialize(Map<String, String> httpClientProperties) {
+    this.connectionTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpClientProperties, HttpClientProperties.APACHE_CONNECTION_TIMEOUT_MS);
+    this.socketTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpClientProperties, HttpClientProperties.APACHE_SOCKET_TIMEOUT_MS);
+    this.acquisitionTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpClientProperties, HttpClientProperties.APACHE_CONNECTION_ACQUISITION_TIMEOUT_MS);
+    this.connectionMaxIdleTimeMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpClientProperties, HttpClientProperties.APACHE_CONNECTION_MAX_IDLE_TIME_MS);
+    this.connectionTimeToLiveMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpClientProperties, HttpClientProperties.APACHE_CONNECTION_TIME_TO_LIVE_MS);
+    this.expectContinueEnabled =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpClientProperties, HttpClientProperties.APACHE_EXPECT_CONTINUE_ENABLED);
+    this.maxConnections =
+        PropertyUtil.propertyAsNullableInt(
+            httpClientProperties, HttpClientProperties.APACHE_MAX_CONNECTIONS);
+    this.tcpKeepAliveEnabled =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpClientProperties, HttpClientProperties.APACHE_TCP_KEEP_ALIVE_ENABLED);
+    this.useIdleConnectionReaperEnabled =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpClientProperties, HttpClientProperties.APACHE_USE_IDLE_CONNECTION_REAPER_ENABLED);
+    this.proxyEndpoint =
+        PropertyUtil.propertyAsString(
+            httpClientProperties, HttpClientProperties.PROXY_ENDPOINT, null);
+  }
+
+  @VisibleForTesting
+  void configureApacheHttpClientBuilder(ApacheHttpClient.Builder apacheHttpClientBuilder) {
+    if (connectionTimeoutMs != null) {
+      apacheHttpClientBuilder.connectionTimeout(Duration.ofMillis(connectionTimeoutMs));
+    }
+    if (socketTimeoutMs != null) {
+      apacheHttpClientBuilder.socketTimeout(Duration.ofMillis(socketTimeoutMs));
+    }
+    if (acquisitionTimeoutMs != null) {
+      apacheHttpClientBuilder.connectionAcquisitionTimeout(Duration.ofMillis(acquisitionTimeoutMs));
+    }
+    if (connectionMaxIdleTimeMs != null) {
+      apacheHttpClientBuilder.connectionMaxIdleTime(Duration.ofMillis(connectionMaxIdleTimeMs));
+    }
+    if (connectionTimeToLiveMs != null) {
+      apacheHttpClientBuilder.connectionTimeToLive(Duration.ofMillis(connectionTimeToLiveMs));
+    }
+    if (expectContinueEnabled != null) {
+      apacheHttpClientBuilder.expectContinueEnabled(expectContinueEnabled);
+    }
+    if (maxConnections != null) {
+      apacheHttpClientBuilder.maxConnections(maxConnections);
+    }
+    if (tcpKeepAliveEnabled != null) {
+      apacheHttpClientBuilder.tcpKeepAlive(tcpKeepAliveEnabled);
+    }
+    if (useIdleConnectionReaperEnabled != null) {
+      apacheHttpClientBuilder.useIdleConnectionReaper(useIdleConnectionReaperEnabled);
+    }
+    if (proxyEndpoint != null) {
+      apacheHttpClientBuilder.proxyConfiguration(
+          ProxyConfiguration.builder().endpoint(URI.create(proxyEndpoint)).build());
+    }
+  }
+
+  public static ApacheHttpClientConfigurations create(Map<String, String> properties) {
+    ApacheHttpClientConfigurations configurations = new ApacheHttpClientConfigurations();
+    configurations.initialize(properties);
+    return configurations;
+  }
+}

--- a/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
+++ b/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package software.amazon.s3tables.iceberg.imports;
+
+import org.apache.iceberg.common.DynClasses;
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.regions.Region;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class AwsClientProperties implements Serializable {
+  /**
+   * Configure the AWS credentials provider used to create AWS clients. A fully qualified concrete
+   * class with package that implements the {@link AwsCredentialsProvider} interface is required.
+   *
+   * <p>Additionally, the implementation class must also have a create() or create(Map) method
+   * implemented, which returns an instance of the class that provides aws credentials provider.
+   *
+   * <p>Example:
+   * client.credentials-provider=software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider
+   *
+   * <p>When set, the default client factory {@link
+   * software.amazon.s3tables.iceberg.S3TablesAwsClientFactory} will use this provider to get AWS credentials
+   * provided instead of reading the default credential chain to get AWS access credentials.
+   */
+  public static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
+
+  /**
+   * Used by the client.credentials-provider configured value that will be used by {@link
+   * software.amazon.s3tables.iceberg.S3TablesAwsClientFactory}
+   * to pass provider-specific properties. Each property consists of a key name and an
+   * associated value.
+   */
+  protected static final String CLIENT_CREDENTIAL_PROVIDER_PREFIX = "client.credentials-provider.";
+
+  /**
+   * Used by {@link software.amazon.s3tables.iceberg.S3TablesAwsClientFactory}.
+   * If set, all AWS clients except STS client will use the given
+   * region instead of the default region chain.
+   */
+  public static final String CLIENT_REGION = "client.region";
+
+  private String clientRegion;
+  private final String clientCredentialsProvider;
+  private final Map<String, String> clientCredentialsProviderProperties;
+
+  public AwsClientProperties() {
+    this.clientRegion = null;
+    this.clientCredentialsProvider = null;
+    this.clientCredentialsProviderProperties = null;
+  }
+
+  public AwsClientProperties(Map<String, String> properties) {
+    this.clientRegion = properties.get(CLIENT_REGION);
+    this.clientCredentialsProvider = properties.get(CLIENT_CREDENTIALS_PROVIDER);
+    this.clientCredentialsProviderProperties =
+        PropertyUtil.propertiesWithPrefix(properties, CLIENT_CREDENTIAL_PROVIDER_PREFIX);
+  }
+
+  public String clientRegion() {
+    return clientRegion;
+  }
+
+  public void setClientRegion(String clientRegion) {
+    this.clientRegion = clientRegion;
+  }
+
+  /**
+   * Configure a client AWS region.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(awsClientProperties::applyClientRegionConfiguration)
+   * </pre>
+   */
+  public <T extends AwsClientBuilder> void applyClientRegionConfiguration(T builder) {
+    if (clientRegion != null) {
+      builder.region(Region.of(clientRegion));
+    }
+  }
+
+  /**
+   * Configure the credential provider for AWS clients.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     DynamoDbClient.builder().applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+   * </pre>
+   */
+  public <T extends AwsClientBuilder> void applyClientCredentialConfigurations(T builder) {
+    if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
+      builder.credentialsProvider(credentialsProvider(this.clientCredentialsProvider));
+    }
+  }
+
+  /**
+   * Returns a credentials provider instance. If params were set, we return a new
+   * credentials instance. If none of the params are set, we try to dynamically load the provided
+   * credentials provider class. Upon loading the class, we try to invoke {@code create(Map<String,
+   * String>)} static method. If that fails, we fall back to {@code create()}. If credential
+   * provider class wasn't set, we fall back to default credentials provider.
+   *
+   * @param accessKeyId the AWS access key ID
+   * @param secretAccessKey the AWS secret access key
+   * @param sessionToken the AWS session token
+   * @return a credentials provider instance
+   */
+  @SuppressWarnings("checkstyle:HiddenField")
+  public AwsCredentialsProvider credentialsProvider(
+      String accessKeyId, String secretAccessKey, String sessionToken) {
+
+    if (!Strings.isNullOrEmpty(accessKeyId) && !Strings.isNullOrEmpty(secretAccessKey)) {
+      if (Strings.isNullOrEmpty(sessionToken)) {
+        return StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(accessKeyId, secretAccessKey));
+      } else {
+        return StaticCredentialsProvider.create(
+            AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken));
+      }
+    }
+
+    if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
+      return credentialsProvider(this.clientCredentialsProvider);
+    }
+
+    // Create a new credential provider for each client
+    return DefaultCredentialsProvider.builder().build();
+  }
+
+  private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {
+    Class<?> providerClass;
+    try {
+      providerClass = DynClasses.builder().impl(credentialsProviderClass).buildChecked();
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot load class %s, it does not exist in the classpath", credentialsProviderClass),
+          e);
+    }
+
+    Preconditions.checkArgument(
+        AwsCredentialsProvider.class.isAssignableFrom(providerClass),
+        String.format(
+            "Cannot initialize %s, it does not implement %s.",
+            credentialsProviderClass, AwsCredentialsProvider.class.getName()));
+
+    try {
+      return createCredentialsProvider(providerClass);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot create an instance of %s, it does not contain a static 'create' or 'create(Map<String, String>)' method",
+              credentialsProviderClass),
+          e);
+    }
+  }
+
+  private AwsCredentialsProvider createCredentialsProvider(Class<?> providerClass)
+      throws NoSuchMethodException {
+    AwsCredentialsProvider provider;
+    try {
+      provider =
+          DynMethods.builder("create")
+              .hiddenImpl(providerClass, Map.class)
+              .buildStaticChecked()
+              .invoke(clientCredentialsProviderProperties);
+    } catch (NoSuchMethodException e) {
+      provider =
+          DynMethods.builder("create").hiddenImpl(providerClass).buildStaticChecked().invoke();
+    }
+    return provider;
+  }
+}

--- a/src/software/amazon/s3tables/iceberg/imports/HttpClientProperties.java
+++ b/src/software/amazon/s3tables/iceberg/imports/HttpClientProperties.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package software.amazon.s3tables.iceberg.imports;
+
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+
+public class HttpClientProperties implements Serializable {
+
+  /**
+   * The type of {@link software.amazon.awssdk.http.SdkHttpClient} implementation used by {@link
+   * software.amazon.s3tables.iceberg.S3TablesAwsClientFactory} If set, all AWS clients will use this specified HTTP
+   * client. If not set, {@link #CLIENT_TYPE_DEFAULT} will be used. For specific types supported, see CLIENT_TYPE_*
+   * defined below.
+   */
+  public static final String CLIENT_TYPE = "http-client.type";
+
+  /**
+   * If this is set under {@link #CLIENT_TYPE}, {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient} will be used as the HTTP Client in {@link
+   * software.amazon.s3tables.iceberg.S3TablesAwsClientFactory}
+   */
+  public static final String CLIENT_TYPE_APACHE = "apache";
+
+  private static final String CLIENT_PREFIX = "http-client.";
+
+  /**
+   * If this is set under {@link #CLIENT_TYPE}, {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient} will be used as the HTTP
+   * Client in {@link software.amazon.s3tables.iceberg.S3TablesAwsClientFactory}
+   */
+  public static final String CLIENT_TYPE_URLCONNECTION = "urlconnection";
+
+  public static final String CLIENT_TYPE_DEFAULT = CLIENT_TYPE_APACHE;
+
+  /**
+   * Used to configure the proxy endpoint. Used by both {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder} and {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}
+   */
+  public static final String PROXY_ENDPOINT = "http-client.proxy-endpoint";
+
+  /**
+   * Used to configure the connection timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder}. This flag only
+   * works when {@link #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_URLCONNECTION}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   */
+  public static final String URLCONNECTION_CONNECTION_TIMEOUT_MS =
+      "http-client.urlconnection.connection-timeout-ms";
+
+  /**
+   * Used to configure the socket timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder}. This flag only
+   * works when {@link #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_URLCONNECTION}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   */
+  public static final String URLCONNECTION_SOCKET_TIMEOUT_MS =
+      "http-client.urlconnection.socket-timeout-ms";
+
+  /**
+   * Used to configure the connection timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_TIMEOUT_MS =
+      "http-client.apache.connection-timeout-ms";
+
+  /**
+   * Used to configure the socket timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_SOCKET_TIMEOUT_MS = "http-client.apache.socket-timeout-ms";
+
+  /**
+   * Used to configure the connection acquisition timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_ACQUISITION_TIMEOUT_MS =
+      "http-client.apache.connection-acquisition-timeout-ms";
+
+  /**
+   * Used to configure the connection max idle time in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_MAX_IDLE_TIME_MS =
+      "http-client.apache.connection-max-idle-time-ms";
+
+  /**
+   * Used to configure the connection time to live in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_TIME_TO_LIVE_MS =
+      "http-client.apache.connection-time-to-live-ms";
+
+  /**
+   * Used to configure whether to enable the expect continue setting for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>In default, this is disabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_EXPECT_CONTINUE_ENABLED =
+      "http-client.apache.expect-continue-enabled";
+
+  /**
+   * Used to configure the max connections number for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_MAX_CONNECTIONS = "http-client.apache.max-connections";
+
+  /**
+   * Used to configure whether to enable the tcp keep alive setting for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}.
+   *
+   * <p>In default, this is disabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_TCP_KEEP_ALIVE_ENABLED =
+      "http-client.apache.tcp-keep-alive-enabled";
+
+  /**
+   * Used to configure whether to use idle connection reaper for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}.
+   *
+   * <p>In default, this is enabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_USE_IDLE_CONNECTION_REAPER_ENABLED =
+      "http-client.apache.use-idle-connection-reaper-enabled";
+
+  private String httpClientType;
+  private final Map<String, String> httpClientProperties;
+
+  public HttpClientProperties() {
+    this.httpClientType = CLIENT_TYPE_DEFAULT;
+    this.httpClientProperties = Collections.emptyMap();
+  }
+
+  public HttpClientProperties(Map<String, String> properties) {
+    this.httpClientType =
+        PropertyUtil.propertyAsString(properties, CLIENT_TYPE, CLIENT_TYPE_DEFAULT);
+    this.httpClientProperties =
+        PropertyUtil.filterProperties(properties, key -> key.startsWith(CLIENT_PREFIX));
+  }
+
+  /**
+   * Configure the httpClient for a client according to the HttpClientType. The two supported
+   * HttpClientTypes are urlconnection and apache
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(awsProperties::applyHttpClientConfigurations)
+   * </pre>
+   */
+  public <T extends AwsSyncClientBuilder> void applyHttpClientConfigurations(T builder) {
+    if (Strings.isNullOrEmpty(httpClientType)) {
+      httpClientType = CLIENT_TYPE_DEFAULT;
+    }
+
+    switch (httpClientType) {
+      case CLIENT_TYPE_URLCONNECTION:
+        UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
+            loadHttpClientConfigurations(UrlConnectionHttpClientConfigurations.class.getName());
+        urlConnectionHttpClientConfigurations.configureHttpClientBuilder(builder);
+        break;
+      case CLIENT_TYPE_APACHE:
+        ApacheHttpClientConfigurations apacheHttpClientConfigurations =
+            loadHttpClientConfigurations(ApacheHttpClientConfigurations.class.getName());
+        apacheHttpClientConfigurations.configureHttpClientBuilder(builder);
+        break;
+      default:
+        throw new IllegalArgumentException("Unrecognized HTTP client type " + httpClientType);
+    }
+  }
+
+  /**
+   * Dynamically load the http client builder to avoid runtime deps requirements of both {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient} and {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient}, since including both will cause error
+   * described in <a href="https://github.com/apache/iceberg/issues/6715">issue#6715</a>
+   */
+  private <T> T loadHttpClientConfigurations(String impl) {
+    Object httpClientConfigurations;
+    try {
+      httpClientConfigurations =
+          DynMethods.builder("create")
+              .hiddenImpl(impl, Map.class)
+              .buildStaticChecked()
+              .invoke(httpClientProperties);
+      return (T) httpClientConfigurations;
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot create %s to generate and configure the http client builder", impl),
+          e);
+    }
+  }
+}

--- a/src/software/amazon/s3tables/iceberg/imports/RetryDetector.java
+++ b/src/software/amazon/s3tables/iceberg/imports/RetryDetector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package software.amazon.s3tables.iceberg.imports;
+
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Metrics are the only reliable way provided by the AWS SDK to determine if an API call was
+ * retried. This class can be attached to an AWS API call and checked after to determine if retries
+ * occurred.
+ */
+public class RetryDetector implements MetricPublisher {
+  private final AtomicBoolean retried = new AtomicBoolean(false);
+
+  @Override
+  public void publish(MetricCollection metricCollection) {
+    if (!retried.get()) {
+      if (metricCollection.metricValues(CoreMetric.RETRY_COUNT).stream().anyMatch(i -> i > 0)) {
+        retried.set(true);
+      } else {
+        metricCollection.children().forEach(this::publish);
+      }
+    }
+  }
+
+  @Override
+  public void close() {}
+
+  public boolean retried() {
+    return retried.get();
+  }
+}

--- a/src/software/amazon/s3tables/iceberg/imports/UrlConnectionHttpClientConfigurations.java
+++ b/src/software/amazon/s3tables/iceberg/imports/UrlConnectionHttpClientConfigurations.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package software.amazon.s3tables.iceberg.imports;
+
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.http.urlconnection.ProxyConfiguration;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+
+class UrlConnectionHttpClientConfigurations {
+
+  private Long httpClientUrlConnectionConnectionTimeoutMs;
+  private Long httpClientUrlConnectionSocketTimeoutMs;
+  private String proxyEndpoint;
+
+  private UrlConnectionHttpClientConfigurations() {}
+
+  public <T extends AwsSyncClientBuilder> void configureHttpClientBuilder(T awsClientBuilder) {
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    configureUrlConnectionHttpClientBuilder(urlConnectionHttpClientBuilder);
+    awsClientBuilder.httpClientBuilder(urlConnectionHttpClientBuilder);
+  }
+
+  private void initialize(Map<String, String> httpClientProperties) {
+    this.httpClientUrlConnectionConnectionTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpClientProperties, HttpClientProperties.URLCONNECTION_CONNECTION_TIMEOUT_MS);
+    this.httpClientUrlConnectionSocketTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpClientProperties, HttpClientProperties.URLCONNECTION_SOCKET_TIMEOUT_MS);
+    this.proxyEndpoint =
+        PropertyUtil.propertyAsString(
+            httpClientProperties, HttpClientProperties.PROXY_ENDPOINT, null);
+  }
+
+  @VisibleForTesting
+  void configureUrlConnectionHttpClientBuilder(
+      UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder) {
+    if (httpClientUrlConnectionConnectionTimeoutMs != null) {
+      urlConnectionHttpClientBuilder.connectionTimeout(
+          Duration.ofMillis(httpClientUrlConnectionConnectionTimeoutMs));
+    }
+    if (httpClientUrlConnectionSocketTimeoutMs != null) {
+      urlConnectionHttpClientBuilder.socketTimeout(
+          Duration.ofMillis(httpClientUrlConnectionSocketTimeoutMs));
+    }
+    if (proxyEndpoint != null) {
+      urlConnectionHttpClientBuilder.proxyConfiguration(
+          ProxyConfiguration.builder().endpoint(URI.create(proxyEndpoint)).build());
+    }
+  }
+
+  public static UrlConnectionHttpClientConfigurations create(
+      Map<String, String> httpClientProperties) {
+    UrlConnectionHttpClientConfigurations configurations =
+        new UrlConnectionHttpClientConfigurations();
+    configurations.initialize(httpClientProperties);
+    return configurations;
+  }
+}

--- a/tst/software/amazon/s3tables/iceberg/S3TablesCatalogTest.java
+++ b/tst/software/amazon/s3tables/iceberg/S3TablesCatalogTest.java
@@ -6,7 +6,6 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -45,6 +44,7 @@ import software.amazon.awssdk.services.s3tables.model.RenameTableResponse;
 import software.amazon.awssdk.services.s3tables.model.TableSummary;
 import software.amazon.awssdk.services.s3tables.model.UpdateTableMetadataLocationRequest;
 import software.amazon.awssdk.services.s3tables.model.UpdateTableMetadataLocationResponse;
+import software.amazon.s3tables.iceberg.imports.AwsClientProperties;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
Fixes #14 

The new S3Tables SDK is causing some issues when using with older AWS SDK versions, likely because it provisions new service endpoints:

```
java.lang.NoSuchFieldError: BUSINESS_METRICS
	at software.amazon.awssdk.services.s3tables.endpoints.internal.AwsEndpointProviderUtils.endpointBuiltIn([AwsEndpointProviderUtils.java:60](http://awsendpointproviderutils.java:60/)) ~[software.amazon.awssdk_s3tables-2.29.26.jar:?]
```

This PR shades the S3Tables SDK and adds it as a part of the publish workflow, so we can publish it to MavenCentral with `runtime` classifier, and users can use it with (for example in Spark):

```
.config("spark.jars.packages","software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.0:runtime")
```