### PR TITLE
Move runtime to separated pacakge to produce right Maven module files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,55 +75,6 @@ test {
     useJUnitPlatform()
 }
 
-shadowJar {
-    // exclude dependencies that are already in Iceberg engine runtimes
-    dependencies {
-        exclude(dependency('com.github.ben-manes.caffeine:caffeine:.*'))
-        exclude(dependency('org.apache.iceberg:.*'))
-        exclude(dependency('com.fasterxml.jackson.core:.*'))
-        exclude(dependency('com.google.errorprone:.*'))
-        exclude(dependency('io.airlift:.*'))
-        exclude(dependency('io.netty:.*'))
-        exclude(dependency('org.apache.avro:.*'))
-        exclude(dependency('org.apache.httpcomponents.client5:.*'))
-        exclude(dependency('org.apache.httpcomponents.core5:.*'))
-        exclude(dependency('org.checkerframework:.*'))
-        exclude(dependency('org.roaringbitmap:.*'))
-        exclude(dependency('org.slf4j:.*'))
-    }
-
-    // relocate project specific dependencies
-    relocate 'software.amazon.awssdk', 'software.amazon.s3tables.shaded.awssdk'
-    relocate 'org.apache.commons', 'software.amazon.s3tables.shaded.org.apache.commons'
-    relocate 'io.netty', 'software.amazon.s3tables.shaded.io.netty'
-    relocate 'org.apache.http', 'software.amazon.s3tables.shaded.org.apache.http'
-
-    // relocate all dependencies that Iceberg engine runtimes already relocates
-    relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
-    relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
-    relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
-    relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
-    relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
-    relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
-    relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
-    relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
-    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
-    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
-    relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
-    relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
-    relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
-    relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
-    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
-    relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
-    relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
-    relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
-
-    archiveClassifier.set("runtime")
-}
-
-shadowJar.finalizedBy javadocJar
-shadowJar.finalizedBy sourcesJar
-
 publishing {
     publications {
         maven(MavenPublication) {
@@ -131,39 +82,6 @@ publishing {
             pom {
                 name = 'Amazon S3 Tables Catalog for Apache Iceberg'
                 description = 'Amazon S3 Tables Catalog for Apache Iceberg.'
-                url = 'https://github.com/awslabs/s3-tables-catalog'
-                inceptionYear = '2024'
-                scm{
-                    url = "https://github.com/awslabs/s3-tables-catalog/tree/main"
-                    connection = "scm:git:ssh://git@github.com:awslabs/s3-tables-catalog.git"
-                    developerConnection = "scm:git:ssh://git@github.com:awslabs/s3-tables-catalog.git"
-                }
-
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution = 'repo'
-                    }
-                }
-
-                developers {
-                    developer {
-                        organization = "Amazon Web Services"
-                        organizationUrl = "https://aws.amazon.com"
-                    }
-                }
-            }
-        }
-
-        shadow(MavenPublication) {
-            from components.shadow
-            artifact sourcesJar
-            artifact javadocJar
-            artifactId = 's3-tables-catalog-for-iceberg-runtime'
-            pom {
-                name = 'Amazon S3 Tables Catalog for Apache Iceberg Runtime Jar'
-                description = 'Amazon S3 Tables Catalog for Apache Iceberg Runtime Jar.'
                 url = 'https://github.com/awslabs/s3-tables-catalog'
                 inceptionYear = '2024'
                 scm{
@@ -199,10 +117,4 @@ publishing {
 
 signing {
     sign publishing.publications.maven
-    sign publishing.publications.shadow
 }
-
-tasks.publishShadowPublicationToMavenLocal.dependsOn tasks.signMavenPublication
-tasks.publishShadowPublicationToMavenRepository.dependsOn tasks.signMavenPublication
-tasks.publishMavenPublicationToMavenLocal.dependsOn tasks.signShadowPublication
-tasks.publishMavenPublicationToMavenRepository.dependsOn tasks.signShadowPublication

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,0 +1,135 @@
+apply plugin: 'java'
+apply plugin: 'com.gradleup.shadow'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+repositories {
+    mavenCentral()
+}
+
+group = 'software.amazon.s3tables'
+version = '0.1.2'
+
+dependencies {
+    implementation project(':')
+//    // Pin Caffeine to 2.9.3, as 3.0 dropped compatibility with JDK8
+//    compileOnly 'com.github.ben-manes.caffeine:caffeine:2.9.3'
+//    compileOnly 'org.apache.commons:commons-configuration2:2.11.0'
+//    compileOnly 'software.amazon.awssdk:apache-client:2.29.26'
+//    compileOnly 'software.amazon.awssdk:aws-core:2.29.26'
+//    compileOnly 'software.amazon.awssdk:dynamodb:2.29.26'
+//    compileOnly 'software.amazon.awssdk:glue:2.29.26'
+//    compileOnly 'software.amazon.awssdk:http-client-spi:2.29.26'
+//    compileOnly 'software.amazon.awssdk:kms:2.29.26'
+//    compileOnly 'software.amazon.awssdk:s3:2.29.26'
+//    compileOnly 'software.amazon.awssdk:sdk-core:2.29.26'
+//    compileOnly 'software.amazon.awssdk:sts:2.29.26'
+//    compileOnly 'software.amazon.awssdk:url-connection-client:2.29.26'
+//    compileOnly 'software.amazon.awssdk:s3tables:2.29.26'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+    withSourcesJar()
+    withJavadocJar()
+}
+
+shadowJar {
+
+//    configurations = [project.configurations.compileClasspath]
+
+    // exclude dependencies that are already in Iceberg engine runtimes
+    dependencies {
+        exclude(dependency('com.github.ben-manes.caffeine:caffeine:.*'))
+        exclude(dependency('org.apache.iceberg:.*'))
+        exclude(dependency('com.fasterxml.jackson.core:.*'))
+        exclude(dependency('com.google.errorprone:.*'))
+        exclude(dependency('io.airlift:.*'))
+        exclude(dependency('io.netty:.*'))
+        exclude(dependency('org.apache.avro:.*'))
+        exclude(dependency('org.apache.httpcomponents.client5:.*'))
+        exclude(dependency('org.apache.httpcomponents.core5:.*'))
+        exclude(dependency('org.checkerframework:.*'))
+        exclude(dependency('org.roaringbitmap:.*'))
+        exclude(dependency('org.slf4j:.*'))
+    }
+
+    // relocate project specific dependencies
+    relocate 'software.amazon.awssdk', 'software.amazon.s3tables.shaded.awssdk'
+    relocate 'org.apache.commons', 'software.amazon.s3tables.shaded.org.apache.commons'
+    relocate 'io.netty', 'software.amazon.s3tables.shaded.io.netty'
+    relocate 'org.apache.http', 'software.amazon.s3tables.shaded.org.apache.http'
+
+    // relocate all dependencies that Iceberg engine runtimes already relocates
+    relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
+    relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
+    relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
+    relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
+    relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
+    relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+    relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+    relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+    relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+    relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+    relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+    relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
+    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+    relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
+    relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
+    relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
+
+    archiveClassifier.set(null)
+}
+
+shadowJar.finalizedBy javadocJar
+shadowJar.finalizedBy sourcesJar
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.shadow
+            artifact sourcesJar
+            artifact javadocJar
+            pom {
+                name = 'Amazon S3 Tables Catalog for Apache Iceberg Runtime Jar'
+                description = 'Amazon S3 Tables Catalog for Apache Iceberg Runtime Jar.'
+                url = 'https://github.com/awslabs/s3-tables-catalog'
+                inceptionYear = '2024'
+                scm{
+                    url = "https://github.com/awslabs/s3-tables-catalog/tree/main"
+                    connection = "scm:git:ssh://git@github.com:awslabs/s3-tables-catalog.git"
+                    developerConnection = "scm:git:ssh://git@github.com:awslabs/s3-tables-catalog.git"
+                }
+
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        organization = "Amazon Web Services"
+                        organizationUrl = "https://aws.amazon.com"
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven{
+            url = 'https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/'
+            credentials(PasswordCredentials)
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.maven
+}

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -12,20 +12,6 @@ version = '0.1.2'
 
 dependencies {
     implementation project(':')
-//    // Pin Caffeine to 2.9.3, as 3.0 dropped compatibility with JDK8
-//    compileOnly 'com.github.ben-manes.caffeine:caffeine:2.9.3'
-//    compileOnly 'org.apache.commons:commons-configuration2:2.11.0'
-//    compileOnly 'software.amazon.awssdk:apache-client:2.29.26'
-//    compileOnly 'software.amazon.awssdk:aws-core:2.29.26'
-//    compileOnly 'software.amazon.awssdk:dynamodb:2.29.26'
-//    compileOnly 'software.amazon.awssdk:glue:2.29.26'
-//    compileOnly 'software.amazon.awssdk:http-client-spi:2.29.26'
-//    compileOnly 'software.amazon.awssdk:kms:2.29.26'
-//    compileOnly 'software.amazon.awssdk:s3:2.29.26'
-//    compileOnly 'software.amazon.awssdk:sdk-core:2.29.26'
-//    compileOnly 'software.amazon.awssdk:sts:2.29.26'
-//    compileOnly 'software.amazon.awssdk:url-connection-client:2.29.26'
-//    compileOnly 'software.amazon.awssdk:s3tables:2.29.26'
 }
 
 java {
@@ -37,9 +23,6 @@ java {
 }
 
 shadowJar {
-
-//    configurations = [project.configurations.compileClasspath]
-
     // exclude dependencies that are already in Iceberg engine runtimes
     dependencies {
         exclude(dependency('com.github.ben-manes.caffeine:caffeine:.*'))

--- a/runtime/src/main/java/software/amazon/s3tables/iceberg/Runtime.java
+++ b/runtime/src/main/java/software/amazon/s3tables/iceberg/Runtime.java
@@ -1,0 +1,4 @@
+package software.amazon.s3tables.iceberg;
+
+public class Runtime {
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,3 +4,7 @@ plugins {
 }
 
 rootProject.name = 's3-tables-catalog-for-iceberg'
+
+include 'runtime'
+
+project(':runtime').name = 's3-tables-catalog-for-iceberg-runtime'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fix the POM module files to produce no classifier after the jar:

```
{
  "formatVersion": "1.1",
  "component": {
    "group": "software.amazon.s3tables",
    "module": "s3-tables-catalog-for-iceberg-runtime",
    "version": "0.1.2",
    "attributes": {
      "org.gradle.status": "release"
    }
  },
  "createdBy": {
    "gradle": {
      "version": "8.11"
    }
  },
  "variants": [
    {
      "name": "shadowRuntimeElements",
      "attributes": {
        "org.gradle.category": "library",
        "org.gradle.dependency.bundling": "shadowed",
        "org.gradle.libraryelements": "jar",
        "org.gradle.usage": "java-runtime"
      },
      "files": [
        {
          "name": "s3-tables-catalog-for-iceberg-runtime-0.1.2.jar",
          "url": "s3-tables-catalog-for-iceberg-runtime-0.1.2.jar",
          "size": 28000735,
          "sha512": "f8cf48fdb52a1a4ef9b4e7b932184261028c14a7075eb3e201e10aaaacbad3f3542221e79224845ff4216ae2c57bb0e2f4e0730ae249c719164a4fd4cffa0ce0",
          "sha256": "f72b456bdf9d42b4e9c4ad7b1b93fdb41be2dac962a8028e150f49bd2a199b77",
          "sha1": "b3a3e04fa62771594ffd833eb5fdaeadd6b5c4ae",
          "md5": "1540cec6ad6272bfbe0e5837b0461151"
        }
      ]
    }
  ]
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
