### PR TITLE
feat: adding custom commit status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ metastore_db/
 .gradle
 /.idea/
 gradle.properties
+/bin/


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/s3-tables-catalog/issues/28

*Description of changes:*
Moving checking custom status to our handler this just helps support older versions of iceberg as well as the newer versions where this is deprecated. 

https://github.com/apache/iceberg/blob/7f14032be8c0538bfa59aba9951ec8a6001035e3/core/src/main/java/org/apache/iceberg/BaseMetastoreOperations.java#L83

Based off of this, but the logic is:
-> On failure check if we updated the metadata correctly. To do this we call our refresh method if the new metadata location is the same as the result of the refresh then we know the commit passed. Otherwise backoff and retry depending on our retry strategy. 


* testing *
Forced a failure and checked that this method can properly pickup a success.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
