### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add the lines below to your pom.xml:
     <version>0.1.4</version>
 </dependency>
 ```
-Or if you using a [BOM](https://aws.amazon.com/blogs/developer/managing-dependencies-with-aws-sdk-for-java-bill-of-materials-module-bom/) just add a dependancy on the s3 tables sdk:
+Or if you using a [BOM](https://aws.amazon.com/blogs/developer/managing-dependencies-with-aws-sdk-for-java-bill-of-materials-module-bom/) just add a dependency on the s3 tables sdk:
 ```
 <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
dependancy -> dependency

*Issue #, if available:*

*Description of changes:*
Minor typo fix in README.md: `dependancy -> dependency`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
