### PR TITLE
Support STS assume role 

### DIFF
--- a/src/software/amazon/s3tables/iceberg/S3TablesAssumeRoleAwsClientFactory.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesAssumeRoleAwsClientFactory.java
@@ -1,0 +1,81 @@
+package software.amazon.s3tables.iceberg;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3tables.S3TablesClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.s3tables.iceberg.imports.AwsClientProperties;
+import software.amazon.s3tables.iceberg.imports.HttpClientProperties;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class S3TablesAssumeRoleAwsClientFactory implements S3TablesAwsClientFactory {
+    protected S3TablesProperties s3TablesProperties;
+    protected AwsClientProperties awsClientProperties;
+    protected HttpClientProperties httpClientProperties;
+    private String roleSessionName;
+
+    public S3TablesAssumeRoleAwsClientFactory() {
+        s3TablesProperties = new S3TablesProperties();
+        awsClientProperties = new AwsClientProperties();
+        httpClientProperties = new HttpClientProperties();
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        s3TablesProperties = new S3TablesProperties(properties);
+        this.httpClientProperties = new HttpClientProperties(properties);
+        awsClientProperties = new AwsClientProperties(properties);
+        this.roleSessionName = genSessionName();
+        Preconditions.checkNotNull(
+                awsClientProperties.clientAssumeRoleArn(),
+                "Cannot initialize AssumeRoleClientConfigFactory with null role ARN");
+        Preconditions.checkNotNull(
+                awsClientProperties.clientAssumeRoleRegion(),
+                "Cannot initialize AssumeRoleClientConfigFactory with null region");
+    }
+
+    @Override
+    public S3TablesClient s3tables() {
+        return S3TablesClient.builder()
+                .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+                .applyMutation(s3TablesProperties::applyS3TableEndpointConfigurations)
+                .applyMutation(this::applyAssumeRoleConfigurations)
+                .build();
+    }
+
+    private String genSessionName() {
+        return String.format("s3tables-aws-%s", UUID.randomUUID());
+    }
+
+    protected <T extends AwsClientBuilder & AwsSyncClientBuilder> T applyAssumeRoleConfigurations(
+            T clientBuilder) {
+        AssumeRoleRequest assumeRoleRequest =
+                AssumeRoleRequest.builder()
+                        .roleArn(awsClientProperties.clientAssumeRoleArn())
+                        .roleSessionName(roleSessionName)
+                        .durationSeconds(awsClientProperties.clientAssumeRoleTimeoutSec())
+                        .externalId(awsClientProperties.clientAssumeRoleExternalId())
+                        .tags(awsClientProperties.stsClientAssumeRoleTags())
+                        .build();
+        clientBuilder
+                .credentialsProvider(
+                        StsAssumeRoleCredentialsProvider.builder()
+                                .stsClient(sts())
+                                .refreshRequest(assumeRoleRequest)
+                                .build())
+                .region(Region.of(awsClientProperties.clientAssumeRoleRegion()));
+        return clientBuilder;
+    }
+
+    private StsClient sts() {
+        return StsClient.builder()
+                .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+                .build();
+    }
+}

--- a/src/software/amazon/s3tables/iceberg/S3TablesAwsClientFactories.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesAwsClientFactories.java
@@ -1,22 +1,12 @@
 package software.amazon.s3tables.iceberg;
 
-import org.apache.iceberg.aws.AwsProperties;
-import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.common.DynConstructors;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
-import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3tables.S3TablesClient;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.s3tables.iceberg.imports.AwsClientProperties;
 import software.amazon.s3tables.iceberg.imports.HttpClientProperties;
 
 import java.util.Map;
-import java.util.UUID;
 
 public class S3TablesAwsClientFactories {
 
@@ -73,74 +63,6 @@ public class S3TablesAwsClientFactories {
                     .applyMutation(s3TablesProperties::applyUserAgentConfigurations)
                     .applyMutation(s3TablesProperties::applyS3TableEndpointConfigurations)
                     .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-                    .build();
-        }
-    }
-
-    public static class S3TablesAssumeRoleClientFactory implements S3TablesAwsClientFactory {
-        protected S3TablesProperties s3TablesProperties;
-        protected AwsClientProperties awsClientProperties;
-        protected HttpClientProperties httpClientProperties;
-        private String roleSessionName;
-
-        public S3TablesAssumeRoleClientFactory() {
-            s3TablesProperties = new S3TablesProperties();
-            awsClientProperties = new AwsClientProperties();
-            httpClientProperties = new HttpClientProperties();
-        }
-
-        @Override
-        public void initialize(Map<String, String> properties) {
-            s3TablesProperties = new S3TablesProperties(properties);
-            this.httpClientProperties = new HttpClientProperties(properties);
-            awsClientProperties = new AwsClientProperties(properties);
-            this.roleSessionName = genSessionName();
-            Preconditions.checkNotNull(
-                    awsClientProperties.clientAssumeRoleArn(),
-                    "Cannot initialize AssumeRoleClientConfigFactory with null role ARN");
-            Preconditions.checkNotNull(
-                    awsClientProperties.clientAssumeRoleRegion(),
-                    "Cannot initialize AssumeRoleClientConfigFactory with null region");
-        }
-
-        @Override
-        public S3TablesClient s3tables() {
-            return S3TablesClient.builder()
-                    .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-                    .applyMutation(httpClientProperties::applyHttpClientConfigurations)
-                    .applyMutation(s3TablesProperties::applyUserAgentConfigurations)
-                    .applyMutation(s3TablesProperties::applyS3TableEndpointConfigurations)
-                    .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-                    .build();
-        }
-
-        private String genSessionName() {
-            return String.format("s3tables-aws-%s", UUID.randomUUID());
-        }
-
-        protected <T extends AwsClientBuilder & AwsSyncClientBuilder> T applyAssumeRoleConfigurations(
-                T clientBuilder) {
-            AssumeRoleRequest assumeRoleRequest =
-                    AssumeRoleRequest.builder()
-                            .roleArn(awsClientProperties.clientAssumeRoleArn())
-                            .roleSessionName(roleSessionName)
-                            .durationSeconds(awsClientProperties.clientAssumeRoleTimeoutSec())
-                            .externalId(awsClientProperties.clientAssumeRoleExternalId())
-                            .tags(awsClientProperties.stsClientAssumeRoleTags())
-                            .build();
-            clientBuilder
-                    .credentialsProvider(
-                            StsAssumeRoleCredentialsProvider.builder()
-                                    .stsClient(sts())
-                                    .refreshRequest(assumeRoleRequest)
-                                    .build())
-                    .region(Region.of(awsClientProperties.clientAssumeRoleRegion()));
-            return clientBuilder;
-        }
-
-        private StsClient sts() {
-            return StsClient.builder()
-                    .applyMutation(httpClientProperties::applyHttpClientConfigurations)
                     .build();
         }
     }

--- a/src/software/amazon/s3tables/iceberg/S3TablesAwsClientFactories.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesAwsClientFactories.java
@@ -1,12 +1,22 @@
 package software.amazon.s3tables.iceberg;
 
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3tables.S3TablesClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.s3tables.iceberg.imports.AwsClientProperties;
 import software.amazon.s3tables.iceberg.imports.HttpClientProperties;
 
 import java.util.Map;
+import java.util.UUID;
 
 public class S3TablesAwsClientFactories {
 
@@ -63,6 +73,74 @@ public class S3TablesAwsClientFactories {
                     .applyMutation(s3TablesProperties::applyUserAgentConfigurations)
                     .applyMutation(s3TablesProperties::applyS3TableEndpointConfigurations)
                     .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+                    .build();
+        }
+    }
+
+    public static class S3TablesAssumeRoleClientFactory implements S3TablesAwsClientFactory {
+        protected S3TablesProperties s3TablesProperties;
+        protected AwsClientProperties awsClientProperties;
+        protected HttpClientProperties httpClientProperties;
+        private String roleSessionName;
+
+        public S3TablesAssumeRoleClientFactory() {
+            s3TablesProperties = new S3TablesProperties();
+            awsClientProperties = new AwsClientProperties();
+            httpClientProperties = new HttpClientProperties();
+        }
+
+        @Override
+        public void initialize(Map<String, String> properties) {
+            s3TablesProperties = new S3TablesProperties(properties);
+            this.httpClientProperties = new HttpClientProperties(properties);
+            awsClientProperties = new AwsClientProperties(properties);
+            this.roleSessionName = genSessionName();
+            Preconditions.checkNotNull(
+                    awsClientProperties.clientAssumeRoleArn(),
+                    "Cannot initialize AssumeRoleClientConfigFactory with null role ARN");
+            Preconditions.checkNotNull(
+                    awsClientProperties.clientAssumeRoleRegion(),
+                    "Cannot initialize AssumeRoleClientConfigFactory with null region");
+        }
+
+        @Override
+        public S3TablesClient s3tables() {
+            return S3TablesClient.builder()
+                    .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+                    .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+                    .applyMutation(s3TablesProperties::applyUserAgentConfigurations)
+                    .applyMutation(s3TablesProperties::applyS3TableEndpointConfigurations)
+                    .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+                    .build();
+        }
+
+        private String genSessionName() {
+            return String.format("s3tables-aws-%s", UUID.randomUUID());
+        }
+
+        protected <T extends AwsClientBuilder & AwsSyncClientBuilder> T applyAssumeRoleConfigurations(
+                T clientBuilder) {
+            AssumeRoleRequest assumeRoleRequest =
+                    AssumeRoleRequest.builder()
+                            .roleArn(awsClientProperties.clientAssumeRoleArn())
+                            .roleSessionName(roleSessionName)
+                            .durationSeconds(awsClientProperties.clientAssumeRoleTimeoutSec())
+                            .externalId(awsClientProperties.clientAssumeRoleExternalId())
+                            .tags(awsClientProperties.stsClientAssumeRoleTags())
+                            .build();
+            clientBuilder
+                    .credentialsProvider(
+                            StsAssumeRoleCredentialsProvider.builder()
+                                    .stsClient(sts())
+                                    .refreshRequest(assumeRoleRequest)
+                                    .build())
+                    .region(Region.of(awsClientProperties.clientAssumeRoleRegion()));
+            return clientBuilder;
+        }
+
+        private StsClient sts() {
+            return StsClient.builder()
+                    .applyMutation(httpClientProperties::applyHttpClientConfigurations)
                     .build();
         }
     }

--- a/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
+++ b/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
@@ -18,7 +18,6 @@
  */
 package software.amazon.s3tables.iceberg.imports;
 
-import org.apache.iceberg.aws.AssumeRoleAwsClientFactory;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -33,6 +32,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.model.Tag;
+import software.amazon.s3tables.iceberg.S3TablesAssumeRoleAwsClientFactory;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -72,14 +72,14 @@ public class AwsClientProperties implements Serializable {
   public static final String CLIENT_REGION = "client.region";
 
   /**
-   * Used by {@link AssumeRoleAwsClientFactory}. If set, all AWS clients will assume a role of the
+   * Used by {@link S3TablesAssumeRoleAwsClientFactory}. If set, all AWS clients will assume a role of the
    * given ARN, instead of using the default credential chain.
    */
   public static final String CLIENT_ASSUME_ROLE_ARN = "client.assume-role.arn";
 
 
   /**
-   * Used by {@link AssumeRoleAwsClientFactory}. Optional external ID used to assume an IAM role.
+   * Used by {@link S3TablesAssumeRoleAwsClientFactory}. Optional external ID used to assume an IAM role.
    *
    * <p>For more details, see
    * https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
@@ -87,7 +87,7 @@ public class AwsClientProperties implements Serializable {
   public static final String CLIENT_ASSUME_ROLE_EXTERNAL_ID = "client.assume-role.external-id";
 
   /**
-   * Used by {@link AssumeRoleAwsClientFactory}. If set, all AWS clients except STS client will use
+   * Used by {@link S3TablesAssumeRoleAwsClientFactory}. If set, all AWS clients except STS client will use
    * the given region instead of the default region chain.
    *
    * <p>The value must be one of {@link software.amazon.awssdk.regions.Region}, such as 'us-east-1'.
@@ -95,19 +95,17 @@ public class AwsClientProperties implements Serializable {
    */
   public static final String CLIENT_ASSUME_ROLE_REGION = "client.assume-role.region";
 
-
-  public static final int CLIENT_ASSUME_ROLE_TIMEOUT_SEC_DEFAULT = 3600;
-
-
   /**
-   * Used by {@link AssumeRoleAwsClientFactory}. The timeout of the assume role session in seconds,
+   * Used by {@link S3TablesAssumeRoleAwsClientFactory}. The timeout of the assume role session in seconds,
    * default to 1 hour. At the end of the timeout, a new set of role session credentials will be
    * fetched through a STS client.
    */
   public static final String CLIENT_ASSUME_ROLE_TIMEOUT_SEC = "client.assume-role.timeout-sec";
 
+  public static final int CLIENT_ASSUME_ROLE_TIMEOUT_SEC_DEFAULT = 3600;
+
   /**
-   * Used by {@link AssumeRoleAwsClientFactory}. Optional session name used to assume an IAM role.
+   * Used by {@link S3TablesAssumeRoleAwsClientFactory}. Optional session name used to assume an IAM role.
    *
    * <p>For more details, see
    * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#ck_rolesessionname
@@ -115,7 +113,7 @@ public class AwsClientProperties implements Serializable {
   public static final String CLIENT_ASSUME_ROLE_SESSION_NAME = "client.assume-role.session-name";
 
   /**
-   * Used by {@link AssumeRoleAwsClientFactory} to pass a list of sessions. Each session tag
+   * Used by {@link S3TablesAssumeRoleAwsClientFactory} to pass a list of sessions. Each session tag
    * consists of a key name and an associated value.
    */
   public static final String CLIENT_ASSUME_ROLE_TAGS_PREFIX = "client.assume-role.tags.";

--- a/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
+++ b/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
@@ -18,10 +18,12 @@
  */
 package software.amazon.s3tables.iceberg.imports;
 
+import org.apache.iceberg.aws.AssumeRoleAwsClientFactory;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -30,9 +32,12 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.model.Tag;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AwsClientProperties implements Serializable {
   /**
@@ -66,14 +71,94 @@ public class AwsClientProperties implements Serializable {
    */
   public static final String CLIENT_REGION = "client.region";
 
+  /**
+   * Used by {@link AssumeRoleAwsClientFactory}. If set, all AWS clients will assume a role of the
+   * given ARN, instead of using the default credential chain.
+   */
+  public static final String CLIENT_ASSUME_ROLE_ARN = "client.assume-role.arn";
+
+
+  /**
+   * Used by {@link AssumeRoleAwsClientFactory}. Optional external ID used to assume an IAM role.
+   *
+   * <p>For more details, see
+   * https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+   */
+  public static final String CLIENT_ASSUME_ROLE_EXTERNAL_ID = "client.assume-role.external-id";
+
+  /**
+   * Used by {@link AssumeRoleAwsClientFactory}. If set, all AWS clients except STS client will use
+   * the given region instead of the default region chain.
+   *
+   * <p>The value must be one of {@link software.amazon.awssdk.regions.Region}, such as 'us-east-1'.
+   * For more details, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+   */
+  public static final String CLIENT_ASSUME_ROLE_REGION = "client.assume-role.region";
+
+
+  public static final int CLIENT_ASSUME_ROLE_TIMEOUT_SEC_DEFAULT = 3600;
+
+
+  /**
+   * Used by {@link AssumeRoleAwsClientFactory}. The timeout of the assume role session in seconds,
+   * default to 1 hour. At the end of the timeout, a new set of role session credentials will be
+   * fetched through a STS client.
+   */
+  public static final String CLIENT_ASSUME_ROLE_TIMEOUT_SEC = "client.assume-role.timeout-sec";
+
+  /**
+   * Used by {@link AssumeRoleAwsClientFactory}. Optional session name used to assume an IAM role.
+   *
+   * <p>For more details, see
+   * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#ck_rolesessionname
+   */
+  public static final String CLIENT_ASSUME_ROLE_SESSION_NAME = "client.assume-role.session-name";
+
+  /**
+   * Used by {@link AssumeRoleAwsClientFactory} to pass a list of sessions. Each session tag
+   * consists of a key name and an associated value.
+   */
+  public static final String CLIENT_ASSUME_ROLE_TAGS_PREFIX = "client.assume-role.tags.";
+
+  private final Set<Tag> stsClientAssumeRoleTags;
+
   private String clientRegion;
   private final String clientCredentialsProvider;
   private final Map<String, String> clientCredentialsProviderProperties;
 
+  private final String clientAssumeRoleArn;
+  private final String clientAssumeRoleExternalId;
+  private final String clientAssumeRoleRegion;
+  private final String clientAssumeRoleSessionName;
+  private final int clientAssumeRoleTimeoutSec;
+
   public AwsClientProperties() {
+    this.stsClientAssumeRoleTags = Sets.newHashSet();
     this.clientRegion = null;
     this.clientCredentialsProvider = null;
     this.clientCredentialsProviderProperties = null;
+
+    this.clientAssumeRoleArn = null;
+    this.clientAssumeRoleExternalId = null;
+    this.clientAssumeRoleRegion = null;
+    this.clientAssumeRoleSessionName = null;
+    this.clientAssumeRoleTimeoutSec = CLIENT_ASSUME_ROLE_TIMEOUT_SEC_DEFAULT;
+  }
+
+  public String clientAssumeRoleArn() {
+    return clientAssumeRoleArn;
+  }
+
+  public String clientAssumeRoleRegion() {
+    return clientAssumeRoleRegion;
+  }
+
+  public int clientAssumeRoleTimeoutSec() {
+    return clientAssumeRoleTimeoutSec();
+  }
+
+  public String clientAssumeRoleExternalId() {
+    return clientAssumeRoleExternalId;
   }
 
   public AwsClientProperties(Map<String, String> properties) {
@@ -81,6 +166,14 @@ public class AwsClientProperties implements Serializable {
     this.clientCredentialsProvider = properties.get(CLIENT_CREDENTIALS_PROVIDER);
     this.clientCredentialsProviderProperties =
         PropertyUtil.propertiesWithPrefix(properties, CLIENT_CREDENTIAL_PROVIDER_PREFIX);
+    this.clientAssumeRoleArn = properties.get(CLIENT_ASSUME_ROLE_ARN);
+    this.clientAssumeRoleExternalId = properties.get(CLIENT_ASSUME_ROLE_EXTERNAL_ID);
+    this.clientAssumeRoleTimeoutSec =
+            PropertyUtil.propertyAsInt(
+                    properties, CLIENT_ASSUME_ROLE_TIMEOUT_SEC, CLIENT_ASSUME_ROLE_TIMEOUT_SEC_DEFAULT);
+    this.clientAssumeRoleRegion = properties.get(CLIENT_ASSUME_ROLE_REGION);
+    this.clientAssumeRoleSessionName = properties.get(CLIENT_ASSUME_ROLE_SESSION_NAME);
+    this.stsClientAssumeRoleTags = toStsTags(properties, CLIENT_ASSUME_ROLE_TAGS_PREFIX);
   }
 
   public String clientRegion() {
@@ -91,6 +184,21 @@ public class AwsClientProperties implements Serializable {
     this.clientRegion = clientRegion;
   }
 
+  public Set<software.amazon.awssdk.services.sts.model.Tag> stsClientAssumeRoleTags() {
+    return stsClientAssumeRoleTags;
+  }
+
+  private Set<software.amazon.awssdk.services.sts.model.Tag> toStsTags(
+          Map<String, String> properties, String prefix) {
+    return PropertyUtil.propertiesWithPrefix(properties, prefix).entrySet().stream()
+            .map(
+                    e ->
+                            software.amazon.awssdk.services.sts.model.Tag.builder()
+                                    .key(e.getKey())
+                                    .value(e.getValue())
+                                    .build())
+            .collect(Collectors.toSet());
+  }
   /**
    * Configure a client AWS region.
    *

--- a/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
+++ b/src/software/amazon/s3tables/iceberg/imports/AwsClientProperties.java
@@ -154,7 +154,7 @@ public class AwsClientProperties implements Serializable {
   }
 
   public int clientAssumeRoleTimeoutSec() {
-    return clientAssumeRoleTimeoutSec();
+    return clientAssumeRoleTimeoutSec;
   }
 
   public String clientAssumeRoleExternalId() {

--- a/tst/software/amazon/s3tables/iceberg/S3TablesCatalogTest.java
+++ b/tst/software/amazon/s3tables/iceberg/S3TablesCatalogTest.java
@@ -6,6 +6,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -14,6 +15,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -429,5 +431,15 @@ public class S3TablesCatalogTest {
 
         S3TablesClient client = catalog.getS3TablesClient();
         assertThat(client).isInstanceOf(TestS3TablesClient.class);
+    }
+
+    @Test
+    public void testAssumeRoleAwsClientFactory() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(S3TablesProperties.CLIENT_FACTORY, S3TablesAssumeRoleAwsClientFactory.class.getName());
+        properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::dummyarn");
+        properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-west-2");
+        S3TablesAwsClientFactory clientFactory = S3TablesAwsClientFactories.from(properties);
+        assertThat(clientFactory).isInstanceOf(S3TablesAssumeRoleAwsClientFactory.class);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#33

*Description of changes:*
Adding support for STSAssumeRoleCredentialProvider. 
The current implementation is missing a custom client factory to support the scenario where customer may want to assume role and perform actions based on those credentials.
Added a new custom factory `S3TablesAssumeRoleAwsClientFactory` to support this scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
