### PR TITLE
Adding support for STS assume role credential provider

### DIFF
--- a/src/software/amazon/s3tables/iceberg/S3TablesAssumeRoleAwsClientFactory.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesAssumeRoleAwsClientFactory.java
@@ -1,0 +1,81 @@
+package software.amazon.s3tables.iceberg;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3tables.S3TablesClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.s3tables.iceberg.imports.AwsClientProperties;
+import software.amazon.s3tables.iceberg.imports.HttpClientProperties;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class S3TablesAssumeRoleAwsClientFactory implements S3TablesAwsClientFactory {
+    protected S3TablesProperties s3TablesProperties;
+    protected AwsClientProperties awsClientProperties;
+    protected HttpClientProperties httpClientProperties;
+    private String roleSessionName;
+
+    public S3TablesAssumeRoleAwsClientFactory() {
+        s3TablesProperties = new S3TablesProperties();
+        awsClientProperties = new AwsClientProperties();
+        httpClientProperties = new HttpClientProperties();
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        s3TablesProperties = new S3TablesProperties(properties);
+        this.httpClientProperties = new HttpClientProperties(properties);
+        awsClientProperties = new AwsClientProperties(properties);
+        this.roleSessionName = genSessionName();
+        Preconditions.checkNotNull(
+                awsClientProperties.clientAssumeRoleArn(),
+                "Cannot initialize AssumeRoleClientConfigFactory with null role ARN");
+        Preconditions.checkNotNull(
+                awsClientProperties.clientAssumeRoleRegion(),
+                "Cannot initialize AssumeRoleClientConfigFactory with null region");
+    }
+
+    @Override
+    public S3TablesClient s3tables() {
+        return S3TablesClient.builder()
+                .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+                .applyMutation(s3TablesProperties::applyS3TableEndpointConfigurations)
+                .applyMutation(this::applyAssumeRoleConfigurations)
+                .build();
+    }
+
+    private String genSessionName() {
+        return String.format("s3tables-aws-%s", UUID.randomUUID());
+    }
+
+    protected <T extends AwsClientBuilder & AwsSyncClientBuilder> T applyAssumeRoleConfigurations(
+            T clientBuilder) {
+        AssumeRoleRequest assumeRoleRequest =
+                AssumeRoleRequest.builder()
+                        .roleArn(awsClientProperties.clientAssumeRoleArn())
+                        .roleSessionName(roleSessionName)
+                        .durationSeconds(awsClientProperties.clientAssumeRoleTimeoutSec())
+                        .externalId(awsClientProperties.clientAssumeRoleExternalId())
+                        .tags(awsClientProperties.stsClientAssumeRoleTags())
+                        .build();
+        clientBuilder
+                .credentialsProvider(
+                        StsAssumeRoleCredentialsProvider.builder()
+                                .stsClient(sts())
+                                .refreshRequest(assumeRoleRequest)
+                                .build())
+                .region(Region.of(awsClientProperties.clientAssumeRoleRegion()));
+        return clientBuilder;
+    }
+
+    private StsClient sts() {
+        return StsClient.builder()
+                .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+                .build();
+    }
+}

--- a/tst/software/amazon/s3tables/iceberg/S3TablesCatalogTest.java
+++ b/tst/software/amazon/s3tables/iceberg/S3TablesCatalogTest.java
@@ -6,6 +6,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -14,6 +15,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -429,5 +431,15 @@ public class S3TablesCatalogTest {
 
         S3TablesClient client = catalog.getS3TablesClient();
         assertThat(client).isInstanceOf(TestS3TablesClient.class);
+    }
+
+    @Test
+    public void testAssumeRoleAwsClientFactory() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(S3TablesProperties.CLIENT_FACTORY, S3TablesAssumeRoleAwsClientFactory.class.getName());
+        properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::dummyarn");
+        properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-west-2");
+        S3TablesAwsClientFactory clientFactory = S3TablesAwsClientFactories.from(properties);
+        assertThat(clientFactory).isInstanceOf(S3TablesAssumeRoleAwsClientFactory.class);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#33 

*Description of changes:*
Adding support for STSAssumeRoleCredentialProvider.
The current implementation is missing a custom client factory to support the scenario where customer may want to assume role and perform actions based on those credentials.
Added a new custom factory S3TablesAssumeRoleAwsClientFactory to support this scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
