### PR TITLE
Update gradle-publish.yml

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -3,7 +3,7 @@ name: Gradle Package
 on:
   workflow_dispatch:
   release:
-    types: [publish]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -3,7 +3,7 @@ name: Gradle Package
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types: [publish]
 
 jobs:
   build:


### PR DESCRIPTION
@shekharsud and I saw that draft releases don't trigger this.

changing from created to publish so we can still be triggered for draft releases
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release

- https://stackoverflow.com/questions/67577655/git-hub-action-on-release-type-released-ran-when-release-deleted

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
