### PR TITLE
Exclude http clients from shading in runtime jar

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -40,7 +40,9 @@ shadowJar {
     }
 
     // relocate project specific dependencies
-    relocate 'software.amazon.awssdk', 'software.amazon.s3tables.shaded.awssdk'
+    relocate('software.amazon.awssdk', 'software.amazon.s3tables.shaded.awssdk') {
+        exclude 'software.amazon.awssdk.http.**'
+    }
     relocate 'org.apache.commons', 'software.amazon.s3tables.shaded.org.apache.commons'
     relocate 'io.netty', 'software.amazon.s3tables.shaded.io.netty'
     relocate 'org.apache.http', 'software.amazon.s3tables.shaded.org.apache.http'


### PR DESCRIPTION
The SDK uses dynamic class loading to find these, and that breaks if we
relocate them, so leave them unshaded.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
