### PR TITLE
Migrate publisher method from Nexus2 to Central Portal

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -52,3 +52,11 @@ jobs:
 
     - name: Publish to GitHub Packages
       run: ./gradlew publish
+
+    - name: Notify Central Publisher Portal
+      run: |
+        curl -X POST \
+          "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${{ vars.MAVEN_GROUP_ID }}" \
+          -H "Authorization: Bearer $(aws secretsmanager get-secret-value --region ${{ secrets.AWS_REGION }} --secret-id ${{ secrets.MAVEN_TOKEN_ID }} --query SecretString --output text | jq -r .bearer)" \
+          -H "Content-Type: application/json" \
+          --fail

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the lines below to your pom.xml:
 <dependency>
     <groupId>software.amazon.s3tables</groupId>
     <artifactId>s3-tables-catalog-for-iceberg</artifactId>
-    <version>0.1.7</version>
+    <version>0.1.8</version>
 </dependency>
 ```
 Or if you using a [BOM](https://aws.amazon.com/blogs/developer/managing-dependencies-with-aws-sdk-for-java-bill-of-materials-module-bom/) just add a dependency on the s3 tables sdk:
@@ -73,7 +73,7 @@ Or for Gradle:
 ```
 dependencies {
     implementation 'software.amazon.awssdk:s3tables:2.29.26'
-    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.7'
+    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.8'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the lines below to your pom.xml:
 <dependency>
     <groupId>software.amazon.s3tables</groupId>
     <artifactId>s3-tables-catalog-for-iceberg</artifactId>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
 </dependency>
 ```
 Or if you using a [BOM](https://aws.amazon.com/blogs/developer/managing-dependencies-with-aws-sdk-for-java-bill-of-materials-module-bom/) just add a dependency on the s3 tables sdk:
@@ -73,7 +73,7 @@ Or for Gradle:
 ```
 dependencies {
     implementation 'software.amazon.awssdk:s3tables:2.29.26'
-    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.5'
+    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.7'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the lines below to your pom.xml:
 <dependency>
     <groupId>software.amazon.s3tables</groupId>
     <artifactId>s3-tables-catalog-for-iceberg</artifactId>
-    <version>0.1.8</version>
+    <version>0.1.7</version>
 </dependency>
 ```
 Or if you using a [BOM](https://aws.amazon.com/blogs/developer/managing-dependencies-with-aws-sdk-for-java-bill-of-materials-module-bom/) just add a dependency on the s3 tables sdk:
@@ -73,7 +73,7 @@ Or for Gradle:
 ```
 dependencies {
     implementation 'software.amazon.awssdk:s3tables:2.29.26'
-    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.8'
+    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.7'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.sonatype.central.testing.amazon'
-version = '0.1.7'
+version = '0.1.8'
 
 // Override main and test code location, as the Java plugin default
 // project layout is 'src/main/java' and 'src/test/java'.

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'com.gradleup.shadow' version '8.3.5'
 }
 
-group = 'com.sonatype.central.testing.amazon'
-version = '0.1.8'
+group = 'software.amazon.s3tables'
+version = '0.1.7'
 
 // Override main and test code location, as the Java plugin default
 // project layout is 'src/main/java' and 'src/test/java'.

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'com.gradleup.shadow' version '8.3.5'
 }
 
-group = 'software.amazon.s3tables'
-version = '0.1.6'
+group = 'com.sonatype.central.testing.amazon'
+version = '0.1.7'
 
 // Override main and test code location, as the Java plugin default
 // project layout is 'src/main/java' and 'src/test/java'.
@@ -108,8 +108,8 @@ publishing {
         }
     }
     repositories {
-        maven{
-            url = 'https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/'
+        maven {
+            url = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
             credentials(PasswordCredentials)
         }
     }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -7,8 +7,8 @@ repositories {
     mavenCentral()
 }
 
-group = 'com.sonatype.central.testing.amazon'
-version = '0.1.8'
+group = 'software.amazon.s3tables'
+version = '0.1.7'
 
 dependencies {
     implementation project(':')

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -7,8 +7,8 @@ repositories {
     mavenCentral()
 }
 
-group = 'software.amazon.s3tables'
-version = '0.1.6'
+group = 'com.sonatype.central.testing.amazon'
+version = '0.1.7'
 
 dependencies {
     implementation project(':')
@@ -106,8 +106,8 @@ publishing {
         }
     }
     repositories {
-        maven{
-            url = 'https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/'
+        maven {
+            url = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
             credentials(PasswordCredentials)
         }
     }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 group = 'com.sonatype.central.testing.amazon'
-version = '0.1.7'
+version = '0.1.8'
 
 dependencies {
     implementation project(':')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Update version from 0.1.6 to 0.1.7
2. Update repo url to https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
3. Add 'Notify Central Publisher Portal' to the github action

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.