### PR TITLE
adds error handling for AccessDeniedException

### DIFF
--- a/src/software/amazon/s3tables/iceberg/S3TablesCatalogOperations.java
+++ b/src/software/amazon/s3tables/iceberg/S3TablesCatalogOperations.java
@@ -47,6 +47,7 @@ import software.amazon.awssdk.services.s3tables.model.GetTableMetadataLocationRe
 import software.amazon.awssdk.services.s3tables.model.NotFoundException;
 import software.amazon.awssdk.services.s3tables.model.UpdateTableMetadataLocationRequest;
 import software.amazon.awssdk.services.s3tables.model.UpdateTableMetadataLocationResponse;
+import software.amazon.awssdk.services.s3tables.model.AccessDeniedException;
 import software.amazon.s3tables.iceberg.imports.RetryDetector;
 
 import java.io.Closeable;
@@ -236,6 +237,9 @@ public class S3TablesCatalogOperations extends BaseMetastoreTableOperations impl
         } catch (ConflictException e) {
             LOG.error("Failed to commit metadata due to conflict: ", e);
             throw new CommitFailedException(e);
+        } catch (AccessDeniedException e) {
+            LOG.error("Failed to commit metadata due to access denied: ", e);
+            throw e;
         } catch (CommitFailedException e) {
             LOG.error("Failed commit metadata: ", e);
             throw e;


### PR DESCRIPTION
*Issue #, if available:* 

Issue 53: Enhance exception handling to propagate AccessDeniedException to the user

*Description of changes:*

- Add specific catch blocks for AccessDeniedException in S3TablesCatalog methods
- Add specific catch block for AccessDeniedException in S3TablesCatalogOperations
- Ensures AccessDeniedException is propagated directly instead of wrapped in RuntimeException
- Fixes issue where customers see generic RuntimeException instead of specific AW

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
