### PR TITLE
Bump version to 0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the lines below to your pom.xml:
 <dependency>
     <groupId>software.amazon.s3tables</groupId>
     <artifactId>s3-tables-catalog-for-iceberg</artifactId>
-    <version>0.1.7</version>
+    <version>0.1.8</version>
 </dependency>
 ```
 Or if you using a [BOM](https://aws.amazon.com/blogs/developer/managing-dependencies-with-aws-sdk-for-java-bill-of-materials-module-bom/) just add a dependency on the s3 tables sdk:
@@ -73,7 +73,7 @@ Or for Gradle:
 ```
 dependencies {
     implementation 'software.amazon.awssdk:s3tables:2.29.26'
-    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.7'
+    implementation 'software.amazon.s3tables:s3-tables-catalog-for-iceberg:0.1.8'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'software.amazon.s3tables'
-version = '0.1.7'
+version = '0.1.8'
 
 // Override main and test code location, as the Java plugin default
 // project layout is 'src/main/java' and 'src/test/java'.

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 group = 'software.amazon.s3tables'
-version = '0.1.7'
+version = '0.1.8'
 
 dependencies {
     implementation project(':')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

AccessDeniedException error handling addressed with https://github.com/awslabs/s3-tables-catalog/commit/0aa83f02e519b85221259035164b6064a05bec96 needs a version bump.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
